### PR TITLE
Added FrequencyEnum for Reset Frequency Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,19 +89,19 @@ $projectsStandardLimit->incrementBy(10);
 $projectsProLimit->decrementBy(3);
 ```
 
-###### Possible values for "reset_frequency" column
+###### Possible values for "reset_frequency" column came from src/Enum/FrequencyEnum.php
 
 - null
-- "every second" // works in Laravel >= 10
-- "every minute"
-- "every hour"
-- "every day"
-- "every week",
-- "every two weeks",
-- "every month",
-- "every quarter",
-- "every six months",
-- "every year"
+- EVERY_SECOND = 'every second' // works in laravel >= 10.x
+- EVERY_MINUTE = 'every minute'
+- EVERY_HOUR  = 'every hour'
+- EVERY_DAY  = 'every day'
+- EVERY_WEEK  = 'every week'
+- EVERY_TWO_WEEKS  = 'every two weeks'
+- EVERY_MONTH  = 'every month'
+- EVERY_QUARTER  = 'every quarter'
+- EVERY_SIX_MONTHS  = 'every six months'
+- EVERY_YEAR  = 'every year'
 
 #### Set Limits on models
 

--- a/src/Enum/FrequencyEnum.php
+++ b/src/Enum/FrequencyEnum.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace NabilHassen\LaravelUsageLimiter\Enum;
+
+use Carbon\Carbon;
+
+enum FrequencyEnum: string
+{
+    case EVERY_SECOND = 'every second';
+    case EVERY_MINUTE = 'every minute';
+    case EVERY_HOUR  = 'every hour';
+    case EVERY_DAY  = 'every day';
+    case EVERY_WEEK  = 'every week';
+    case EVERY_TWO_WEEKS  = 'every two weeks';
+    case EVERY_MONTH  = 'every month';
+    case EVERY_QUARTER  = 'every quarter';
+    case EVERY_SIX_MONTHS  = 'every six months';
+    case EVERY_YEAR  = 'every year';
+
+    public static function toArray(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public function getCarbonEquivalent(string|Carbon $lastReset): Carbon
+    {
+        $lastReset = Carbon::parse($lastReset);
+
+        return match ($this) {
+            self::EVERY_SECOND => $lastReset->addSecond(),
+            self::EVERY_MINUTE => $lastReset->addMinute(),
+            self::EVERY_HOUR => $lastReset->addHour(),
+            self::EVERY_DAY => $lastReset->addDay(),
+            self::EVERY_WEEK => $lastReset->addWeek(),
+            self::EVERY_TWO_WEEKS => $lastReset->addWeeks(2),
+            self::EVERY_MONTH => $lastReset->addMonth(),
+            self::EVERY_QUARTER => $lastReset->addQuarter(),
+            self::EVERY_SIX_MONTHS => $lastReset->addMonths(6),
+            self::EVERY_YEAR => $lastReset->addYear(),
+        };
+    }
+}

--- a/src/Models/Limit.php
+++ b/src/Models/Limit.php
@@ -25,19 +25,6 @@ class Limit extends Model implements LimitContract
         'reset_frequency' => FrequencyEnum::class,
     ];
 
-    // protected static array $resetFrequencyPossibleValues = [
-    //     'every second',
-    //     'every minute',
-    //     'every hour',
-    //     'every day',
-    //     'every week',
-    //     'every two weeks',
-    //     'every month',
-    //     'every quarter',
-    //     'every six months',
-    //     'every year',
-    // ];
-
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);

--- a/src/Models/Limit.php
+++ b/src/Models/Limit.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use NabilHassen\LaravelUsageLimiter\Contracts\Limit as LimitContract;
+use NabilHassen\LaravelUsageLimiter\Enum\FrequencyEnum;
 use NabilHassen\LaravelUsageLimiter\Exceptions\InvalidLimitResetFrequencyValue;
 use NabilHassen\LaravelUsageLimiter\Exceptions\LimitAlreadyExists;
 use NabilHassen\LaravelUsageLimiter\Exceptions\LimitDoesNotExist;
@@ -20,18 +21,22 @@ class Limit extends Model implements LimitContract
 
     protected $guarded = ['id', 'created_at', 'updated_at', 'deleted_at'];
 
-    protected static array $resetFrequencyPossibleValues = [
-        'every second',
-        'every minute',
-        'every hour',
-        'every day',
-        'every week',
-        'every two weeks',
-        'every month',
-        'every quarter',
-        'every six months',
-        'every year',
+    protected $casts = [
+        'reset_frequency' => FrequencyEnum::class,
     ];
+
+    // protected static array $resetFrequencyPossibleValues = [
+    //     'every second',
+    //     'every minute',
+    //     'every hour',
+    //     'every day',
+    //     'every week',
+    //     'every two weeks',
+    //     'every month',
+    //     'every quarter',
+    //     'every six months',
+    //     'every year',
+    // ];
 
     public function __construct(array $attributes = [])
     {
@@ -75,7 +80,7 @@ class Limit extends Model implements LimitContract
         if (
             Arr::has($data, ['reset_frequency']) &&
             filled($data['reset_frequency']) &&
-            array_search($data['reset_frequency'], static::$resetFrequencyPossibleValues) === false
+            !in_array($data['reset_frequency'], FrequencyEnum::toArray())
         ) {
             throw new InvalidLimitResetFrequencyValue;
         }
@@ -141,6 +146,6 @@ class Limit extends Model implements LimitContract
 
     public function getResetFrequencyOptions(): Collection
     {
-        return collect(static::$resetFrequencyPossibleValues);
+        return collect(FrequencyEnum::toArray());
     }
 }

--- a/tests/Feature/LimitManagerTest.php
+++ b/tests/Feature/LimitManagerTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use NabilHassen\LaravelUsageLimiter\Contracts\Limit;
+use NabilHassen\LaravelUsageLimiter\Enum\FrequencyEnum;
 use NabilHassen\LaravelUsageLimiter\Exceptions\InvalidLimitResetFrequencyValue;
 use NabilHassen\LaravelUsageLimiter\LimitManager;
 use NabilHassen\LaravelUsageLimiter\Tests\TestCase;
@@ -112,7 +113,9 @@ class LimitManagerTest extends TestCase
 
     public function test_get_next_reset_returns_carbon_date(): void
     {
-        $date = $this->limitManagerClass->getNextReset(app(Limit::class)->getResetFrequencyOptions()->random(), now());
+        $limit_frequency = FrequencyEnum::from(app(Limit::class)->getResetFrequencyOptions()->random());
+
+        $date = $this->limitManagerClass->getNextReset($limit_frequency, now());
 
         $this->assertInstanceOf(Carbon::class, $date);
     }


### PR DESCRIPTION
## Changes:

Introduced a new enum FrequencyEnum in the file src/Enum/FrequencyEnum.php.
The FrequencyEnum defines the possible values for the reset_frequency column.
Added the following values in the enum:

- `EVERY_SECOND` = 'every second'
- `EVERY_MINUTE` = 'every minute'
- `EVERY_HOUR` = 'every hour'
- `EVERY_DAY` = 'every day'
- `EVERY_WEEK` = 'every week'
- `EVERY_TWO_WEEKS` = 'every two weeks'
- `EVERY_MONTH` = 'every month'
- `EVERY_QUARTER` = 'every quarter'
- `EVERY_SIX_MONTHS` = 'every six months'
- `EVERY_YEAR` = 'every year'

## Benefits:

Centralized management of reset frequency values.
Simplifies handling time-based operations with the integration of Carbon date-time library.
Ensures consistency and reduces the risk of errors associated with manual time calculations.


Please review the changes and let me know if any further modifications are needed.

